### PR TITLE
prepare values to skip expensive Operations

### DIFF
--- a/commercedbsync/src/com/sap/cx/boosters/commercedbsync/dataset/impl/DefaultDataSet.java
+++ b/commercedbsync/src/com/sap/cx/boosters/commercedbsync/dataset/impl/DefaultDataSet.java
@@ -29,12 +29,15 @@ public class DefaultDataSet implements DataSet {
     private final List<DataColumn> columnOrder;
     private final List<List<Object>> result;
     private final String partition;
+    private final List<String> columnNames;
 
     public DefaultDataSet(int batchId, int columnCount, List<DataColumn> columnOrder, List<List<Object>> result,
             final String partition) {
         this.batchId = batchId;
         this.columnCount = columnCount;
         this.columnOrder = Collections.unmodifiableList(columnOrder);
+        this.columnNames =
+				columnOrder.stream().map(DataColumn::getColumnName).map(String::toLowerCase).toList();
         this.result = result.stream().map(Collections::unmodifiableList).collect(Collectors.toList());
         this.partition = partition;
     }
@@ -97,7 +100,7 @@ public class DefaultDataSet implements DataSet {
         if (StringUtils.isEmpty(column)) {
             return false;
         }
-        return columnOrder.stream().map(DataColumn::getColumnName).anyMatch(column::equalsIgnoreCase);
+        return columnNames.contains(column.toLowerCase());
     }
 
     @Override
@@ -115,8 +118,7 @@ public class DefaultDataSet implements DataSet {
     }
 
     protected int findColumnIndex(String columnName) {
-        return IterableUtils.indexOf(columnOrder,
-                dataColumn -> dataColumn.getColumnName().equalsIgnoreCase(columnName));
+        return columnNames.indexOf(columnName.toLowerCase());
     }
 
     public String toString() {


### PR DESCRIPTION
# Scenario
We have a Table huge table with  > 2 million rows and ~ 670 columns.
Batch Size is 5000
This results in 3.350.000 Values per Batch

# Problem
We found out that migrating this Table is causing a lot of Stalled Results.
Also we saw that preparing the `PreparedStatements` in `com.sap.cx.boosters.commercedbsync.strategy.impl.CopyPipeWriterTask#process` takes most of the Time.

While executing the Batches takes ~ 7 Seconds,  the preparatin itself takes 5 Minutes.
During this Time we were able to see in the Logs, that other Pipes waited a long time to get a free Writer Task.

With Dynatrace, we were able to identify the bottleneck, which was the Lookup of Data via Iterations

# Solution
Prepare/Cache the data that needs to be iterated to reduce the overhead 